### PR TITLE
Fix typos and add test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@ ipa-chart
 =========
 To run locally, requires apache2, mysql-server, php.
 Restart apache2 server and place index.html and all associated files in /var/www/http, access with localhost in browser. 
+
+Running tests
+-------------
+Ensure PHP is installed. Execute the test suite with:
+
+    php -d short_open_tag=On tests/ChompTest.php
+

--- a/index.html
+++ b/index.html
@@ -448,7 +448,7 @@ $(function() {
 <div id="footer">
 	<a href='http://smu-facweb.smu.ca/~s0949176/sammy/' target='_blank' class='link'>Sagittal Sections</a><br />
 	Feel free to <a href='submit.html' class='link'>submit a language</a> for addition to the chart.<br />
-	Open sourced on <a href="http://www.github.com/matthewmorrone1/ipa-chart" class='link'>Github</a><br />
+	Open sourced on <a href="http://www.github.com/matthewmorrone1/ipa-chart" class='link'>GitHub</a><br />
 	Make sure your browser is set to standard <a href='http://www.unc.edu/~jlsmith/ipa-fonts.html' target='_blank' class='link'>Unicode</a> fonts in order for the page to properly render.<br />
 	Not configured for Internet Explorer. Designed in <a href='https://www.google.com/intl/en/chrome/browser/' target='_blank' class='link'>Google Chrome</a>.<br />
 	Please contact me with any questions, suggestions for features, errors encountered or language requests.<br />

--- a/submit.html
+++ b/submit.html
@@ -248,7 +248,7 @@ $(function() {
 <div id=footer>
 	Make sure your browser is set to standard <a href='http://www.unc.edu/~jlsmith/ipa-fonts.html' target='_blank' class='link'>Unicode</a> fonts in order for the page to properly render.<br />
 	Not configured for Internet Explorer. Designed in <a href='https://www.google.com/intl/en/chrome/browser/' target='_blank' class='link'>Google Chrome</a>.<br />
-	Please contact me with any question, suggestions for features, errors encountered or language requests.<br />
+	Please contact me with any questions, suggestions for features, errors encountered or language requests.<br />
 	&copy;<span id='year'></span> Matthew Morrone <a href="mailto:matthewmorrone1@gmail.com" class='link'>matthewmorrone1@gmail.com</a>
 </div>
 </body>

--- a/tests/ChompTest.php
+++ b/tests/ChompTest.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__ . '/../ipa.php';
+$result = chomp('example.txt', 4);
+if ($result !== 'example') {
+    echo "Failed: expected 'example', got '$result'\n";
+    exit(1);
+}
+echo "OK\n";


### PR DESCRIPTION
## Summary
- correct GitHub spelling in `index.html`
- normalize phrasing in `submit.html`
- add a simple PHP test for `chomp`
- document running the test

## Testing
- `php -d short_open_tag=On tests/ChompTest.php`

------
https://chatgpt.com/codex/tasks/task_e_684f2eda59b08330890720eed5013c29

## Summary by Sourcery

Fix content typos in HTML pages, add and document a PHP test for the chomp function

Enhancements:
- Correct GitHub spelling in index.html
- Normalize contact phrasing in submit.html

Documentation:
- Document running the PHP test suite in README

Tests:
- Add a simple PHP test for the chomp function